### PR TITLE
Blocking bugfix for mysql lock

### DIFF
--- a/src/NinjaMutex/Lock/LockAbstract.php
+++ b/src/NinjaMutex/Lock/LockAbstract.php
@@ -80,7 +80,7 @@ abstract class LockAbstract implements LockInterface
         $start = microtime(true);
         $end = $start + $timeout / 1000;
         $locked = false;
-        while (!(empty($this->locks[$name]) && $locked = $this->getLock($name, $blocking)) && $timeout > 0 && microtime(true) < $end) {
+        while (!(empty($this->locks[$name]) && $locked = $this->getLock($name, $blocking)) && ($blocking || ($timeout > 0 && microtime(true) < $end))) {
             usleep(static::USLEEP_TIME);
         }
 


### PR DESCRIPTION
GET_LOCK doesn't block in mySQL, so the $blocking variable has no effect when passed to getLock in the mysql driver. This fixes the blocking logic in the abstract base class.