### PR TITLE
fclose lock files when released

### DIFF
--- a/src/NinjaMutex/Lock/FlockLock.php
+++ b/src/NinjaMutex/Lock/FlockLock.php
@@ -65,6 +65,8 @@ class FlockLock extends LockAbstract
         if (isset($this->files[$name])) {
             flock($this->files[$name], LOCK_UN); // @todo Can LOCK_UN fail?
             unset($this->locks[$name]);
+            fclose($this->files[$name]);
+            unset($this->files[$name]);
 
             return true;
         }


### PR DESCRIPTION
This prevents too many open files from being left open by a long-running process.
We found out the hard way by getting a "Too many open files" in a highly parallel worker app.