### PR TITLE
Decouple lock information provision from the lock itself, disable DNS…

### DIFF
--- a/src/Lock/BasicLockInformationProvider.php
+++ b/src/Lock/BasicLockInformationProvider.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of ninja-mutex.
+ *
+ * (C) Kamil Dziedzic <arvenil@klecza.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace NinjaMutex\Lock;
+
+
+class BasicLockInformationProvider implements LockInformationProviderInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function getLockInformation()
+    {
+        $pid = getmypid();
+        $hostname = gethostname();
+
+        $params = array();
+        $params[] = $pid;
+        $params[] = $hostname;
+
+        return $params;
+    }
+}

--- a/src/Lock/LockAbstract.php
+++ b/src/Lock/LockAbstract.php
@@ -21,20 +21,20 @@ abstract class LockAbstract implements LockInterface
     const USLEEP_TIME = 100;
 
     /**
-     * Information which allows to track down process which acquired lock
+     * Provides information which allows to track down process which acquired lock
      *
-     * @var array
+     * @var LockInformationProviderInterface
      */
-    protected $lockInformation = array();
+    protected $lockInformationProvider;
 
     /**
      * @var array
      */
     protected $locks = array();
 
-    public function __construct()
+    public function __construct(LockInformationProviderInterface $informationProvider = null)
     {
-        $this->lockInformation = $this->generateLockInformation();
+        $this->lockInformationProvider = $informationProvider ? : new BasicLockInformationProvider();
     }
 
     public function __clone()
@@ -101,37 +101,28 @@ abstract class LockAbstract implements LockInterface
     abstract protected function getLock($name, $blocking);
 
     /**
-     * Information generate by this method allow to track down process which acquired lock
-     * .
-     * By default it returns array with:
-     * 1. pid
-     * 2. server_ip
-     * 3. server_name
-     *
-     * @return array
-     */
-    protected function generateLockInformation()
-    {
-        $pid = getmypid();
-        $hostname = gethostname();
-        $host = gethostbyname($hostname);
-
-        // Compose data to one string
-        $params = array();
-        $params[] = $pid;
-        $params[] = $host;
-        $params[] = $hostname;
-
-        return $params;
-    }
-
-    /**
      * Information returned by this method allow to track down process which acquired lock
      * .
      * @return array
      */
     protected function getLockInformation()
     {
-        return $this->lockInformation;
+        return $this->lockInformationProvider->getLockInformation();
+    }
+
+    /**
+     * @return LockInformationProviderInterface
+     */
+    public function getLockInformationProvider()
+    {
+        return $this->lockInformationProvider;
+    }
+
+    /**
+     * @param LockInformationProviderInterface $lockInformationProvider
+     */
+    public function setLockInformationProvider($lockInformationProvider)
+    {
+        $this->lockInformationProvider = $lockInformationProvider;
     }
 }

--- a/src/Lock/LockInformationProviderInterface.php
+++ b/src/Lock/LockInformationProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of ninja-mutex.
+ *
+ * (C) Kamil Dziedzic <arvenil@klecza.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace NinjaMutex\Lock;
+
+/**
+ * Provides lock debugging information
+ * @package NinjaMutex\Lock
+ */
+interface LockInformationProviderInterface
+{
+    /**
+     * Gathers lock debug information
+     * @return array
+     */
+    public function getLockInformation();
+}

--- a/src/Lock/ResolvedHostnameLockInformationProvider.php
+++ b/src/Lock/ResolvedHostnameLockInformationProvider.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of ninja-mutex.
+ *
+ * (C) Kamil Dziedzic <arvenil@klecza.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace NinjaMutex\Lock;
+
+
+class ResolvedHostnameLockInformationProvider extends BasicLockInformationProvider
+{
+    /**
+     * Adds resolved host IP to the provided information
+     * (WARNING! Using DNS queries at runtime may introduce significant delays to script execution, use with caution!)
+     * @return array
+     */
+    public function getLockInformation()
+    {
+        $params = parent::gatherInformation();
+        $params[] = gethostbyname(gethostname());
+
+        return $params;
+    }
+
+}


### PR DESCRIPTION
… lookup by default, add it as an optional information provider.

The DNS lookup adds significant delays (up to 5 seconds) in some environments, and is not necessary by default in my opinion.