### PR TITLE
[bc] allow passing additional params to PDO

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
         "predis/predis" : "Create mutex using Predis (client library for Redis)",
         "ext-memcache": "Create mutex using memcache extension",
         "ext-memcached": "Create mutex using memcached extension",
-        "ext-pdo_mysql": "Create mutex using MySql"
+        "ext-pdo_mysql": "Create mutex using MySQL PDO"
     }
 }

--- a/src/Lock/MySQLPDOLock.php
+++ b/src/Lock/MySQLPDOLock.php
@@ -49,11 +49,14 @@ class MySQLPDOLock extends LockAbstract
     /**
      * Provide data for PDO connection
      *
+     * @link http://php.net/manual/en/pdo.construct.php
      * @param string $dsn
-     * @param string $username
-     * @param string $passwd
-     * @param array $options
-     * @param string $classname class name to create as PDO connection
+     * @param string $username [optional]
+     * @param string $passwd   [optional]
+     * @param array  $options  [optional]
+     *
+     * @param string $classname class name to create as PDO connection,
+     *                          by default this is PDO, but in tests we can inject MockPDO
      */
     public function __construct($dsn, $username = null, $passwd = null, $options = null, $classname = 'PDO')
     {

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -210,7 +210,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function provideMysqlLock()
     {
-        return array(new MySQLPDOLock('', 'root', ''));
+        return array(new MySQLPDOLock('mysql:', 'root', ''));
     }
 
     /**

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -13,7 +13,7 @@ use NinjaMutex\Lock\DirectoryLock;
 use NinjaMutex\Lock\FlockLock;
 use NinjaMutex\Lock\MemcachedLock;
 use NinjaMutex\Lock\MemcacheLock;
-use NinjaMutex\Lock\MySqlLock;
+use NinjaMutex\Lock\MySQLPDOLock;
 use NinjaMutex\Lock\PredisRedisLock;
 use NinjaMutex\Lock\PhpRedisLock;
 use NinjaMutex\Tests\Lock\Fabric\MemcachedLockFabric;
@@ -166,7 +166,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function provideMysqlMockLock()
     {
-        return array(new MySqlLock('', '', '', 3306, 'NinjaMutex\Tests\Mock\MockPDO'));
+        return array(new MySQLPDOLock('', null, null, null, 'NinjaMutex\Tests\Mock\MockPDO'));
     }
 
     /**
@@ -210,7 +210,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function provideMysqlLock()
     {
-        return array(new MySqlLock('root', '', '127.0.0.1'));
+        return array(new MySQLPDOLock('', 'root', ''));
     }
 
     /**

--- a/tests/Mock/MockPDO.php
+++ b/tests/Mock/MockPDO.php
@@ -10,6 +10,7 @@
 namespace NinjaMutex\Tests\Mock;
 
 use PDO;
+use PDOStatement;
 
 /**
  * Mock PDO to mimic *_lock functionality
@@ -33,16 +34,32 @@ class MockPDO extends PDO
      */
     protected $current = array();
 
-    public function __construct($dsn, $user, $password)
+    public function __construct($dsn, $user, $password, $options)
     {
         $this->_mock_pdo_statement = new MockPDOStatement();
     }
 
     /**
-     * @param  string           $statement
-     * @return MockPDOStatement
+     * @param string $statement <p>
+     * The SQL statement to prepare and execute.
+     * </p>
+     * <p>
+     * Data inside the query should be properly escaped.
+     * </p>
+     * @param int $mode <p>
+     * The fetch mode must be one of the PDO::FETCH_* constants.
+     * </p>
+     * @param mixed $arg3 <p>
+     * The second and following parameters are the same as the parameters for PDOStatement::setFetchMode.
+     * </p>
+     * @param array $ctorargs [optional] <p>
+     * Arguments of custom class constructor when the <i>mode</i>
+     * parameter is set to <b>PDO::FETCH_CLASS</b>.
+     * </p>
+     * @return PDOStatement <b>PDO::query</b> returns a PDOStatement object, or <b>FALSE</b>
+     * on failure.
      */
-    public function query($statement)
+    public function query ($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, array $ctorargs = array())
     {
         if (preg_match('/RELEASE_LOCK\((.*)\)/', $statement, $m)) {
             return $this->_mock_release_lock($m[1]);

--- a/tests/Mock/MockPDO.php
+++ b/tests/Mock/MockPDO.php
@@ -34,12 +34,22 @@ class MockPDO extends PDO
      */
     protected $current = array();
 
-    public function __construct($dsn, $user, $password, $options)
+    /**
+     * Creates a PDO instance representing a connection to a database
+     * @link http://php.net/manual/en/pdo.construct.php
+     * @param $dsn
+     * @param $username [optional]
+     * @param $passwd [optional]
+     * @param $options [optional]
+     */
+    public function __construct($dsn, $username, $passwd, $options)
     {
         $this->_mock_pdo_statement = new MockPDOStatement();
     }
 
     /**
+     * Executes an SQL statement, returning a result set as a PDOStatement object
+     * @link http://php.net/manual/en/pdo.query.php
      * @param string $statement <p>
      * The SQL statement to prepare and execute.
      * </p>

--- a/tests/Mock/MockPDO.php
+++ b/tests/Mock/MockPDO.php
@@ -39,8 +39,8 @@ class MockPDO extends PDO
      * @link http://php.net/manual/en/pdo.construct.php
      * @param $dsn
      * @param $username [optional]
-     * @param $passwd [optional]
-     * @param $options [optional]
+     * @param $passwd   [optional]
+     * @param $options  [optional]
      */
     public function __construct($dsn, $username, $passwd, $options)
     {
@@ -69,7 +69,7 @@ class MockPDO extends PDO
      * @return PDOStatement <b>PDO::query</b> returns a PDOStatement object, or <b>FALSE</b>
      * on failure.
      */
-    public function query ($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, array $ctorargs = array())
+    public function query($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, array $ctorargs = array())
     {
         if (preg_match('/RELEASE_LOCK\((.*)\)/', $statement, $m)) {
             return $this->_mock_release_lock($m[1]);
@@ -93,7 +93,7 @@ class MockPDO extends PDO
      * SQL statement. Returns <b>FALSE</b> if the driver does not support quoting in
      * this way.
      */
-    public function quote ($string, $parameter_type = PDO::PARAM_STR)
+    public function quote($string, $parameter_type = PDO::PARAM_STR)
     {
         return $string;
     }


### PR DESCRIPTION
This should allow SSL options requested in #32 

At the same time I've changed params to be the same as PDO::__construct(), this brakes backward compatibility, so I've decided to change class name, so user will be forced to update code and passed params, otherwise old class could be called with wrong params.