### PR TITLE
[fix] remove destructor in mutex

### DIFF
--- a/src/Mutex.php
+++ b/src/Mutex.php
@@ -83,29 +83,6 @@ class Mutex
     }
 
     /**
-     * Try to release any obtained locks when object is destroyed
-     *
-     * This is a safe guard for cases when your php script dies unexpectedly.
-     * It's not guaranteed it will work either.
-     *
-     * You should not depend on __destruct() to release your locks,
-     * instead release them with `$released = $this->releaseLock()`A
-     * and check `$released` if lock was properly released
-     */
-    public function __destruct()
-    {
-        while ($this->isAcquired()) {
-            $released = $this->releaseLock();
-            if (!$released) {
-                throw new UnrecoverableMutexException(sprintf(
-                    'Cannot release lock in Mutex __destruct(): %s',
-                    $this->name
-                ));
-            }
-        }
-    }
-
-    /**
      * Check if Mutex is acquired
      *
      * @return bool


### PR DESCRIPTION
  Mutex destructor is used to as a fail safe to release locks in case process is terminated unexpectedly, this is not really needed and could lead to errors
    * The actual lock provider responsible for releasing the lock could be destructed before the mutex, during shutdown there is no guarantee in order of which objects are destructed
    * All lock providers extend the LockAbstaract class which already has a destructor responsible for freeing locks in case of failure
    * Throwig exception in the destructor is not a good idea, doing so triggers a fatal error